### PR TITLE
chore: version assertion failing in release workflow

### DIFF
--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -58,7 +58,8 @@ describe('CfnGuardPlugin', () => {
     });
 
     // THEN
-    expect(validator.version).toEqual('0.0.0');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    expect(validator.version).toEqual(require('../package.json').version);
     expect(validator.ruleIds).toEqual(['efsrule', 's3rule']);
     expect(execMock).toHaveBeenCalledTimes(4);
     expect(execMock).toHaveBeenNthCalledWith(1, expect.arrayContaining([


### PR DESCRIPTION
In the release workflow, the tests are executed after the `bump`, so the version inside `package.json` is no longer `0.0.0`, and the test fails:

```console
  ● CfnGuardPlugin › cfn-guard called

    expect(received).toEqual(expected) // deep equality

    Expected: "0.0.0"
    Received: "0.0.51"

      59 |
      60 |     // THEN
    > 61 |     expect(validator.version).toEqual('0.0.0');
```

Instead, compare to the version in `package.json`.