### PR TITLE
chore: unlock aws-cdk-lib `peerDependency` version

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -43,7 +43,6 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "2.76.0",
       "type": "build"
     },
     {
@@ -144,7 +143,6 @@
     },
     {
       "name": "aws-cdk-lib",
-      "version": "^2.76.0",
       "type": "peer"
     }
   ],

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -349,19 +349,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,aws-cdk-lib,jsii-rosetta,jsii'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,jsii-rosetta,jsii'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,aws-cdk-lib,jsii-rosetta,jsii'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,jsii-rosetta,jsii'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,aws-cdk-lib,jsii-rosetta,jsii'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,jsii-rosetta,jsii'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,aws-cdk-lib,jsii-rosetta,jsii'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,jsii-rosetta,jsii'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,aws-cdk-lib,jsii-rosetta,jsii'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@types/fs-extra,@types/klaw,jsii-rosetta,jsii'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -41,7 +41,7 @@ const project = new CdklabsJsiiProject({
   release: true,
   repositoryUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard.git',
   peerDeps: [
-    'aws-cdk-lib@^2.76.0',
+    'aws-cdk-lib',
   ],
   publishToPypi: {
     distName: 'cdklabs.cdk-validator-cfnguard',


### PR DESCRIPTION
No need to lock it. 