### PR TITLE
feat: upgrade cfn-guard to 3.0.0

### DIFF
--- a/guard-version.json
+++ b/guard-version.json
@@ -1,4 +1,4 @@
 {
-  "release_id": 82741998,
-  "version": "2.1.3"
+  "release_id": 110407150,
+  "version": "3.0.0"
 }

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,4 +1,3 @@
-import * as path from 'path';
 import {
   PolicyViolationBeta1,
   PolicyViolatingResourceBeta1,
@@ -48,10 +47,9 @@ interface Traversed {
  */
 export interface GuardResult {
   /**
-   * TODO: figure out what this is
-   * it's always an empty string
+   * The name of the template
    */
-  readonly name?: string;
+  readonly name: string;
 
   /**
    * The overall status of the rule, pass or fail
@@ -152,7 +150,6 @@ export class ViolationCheck {
   constructor(
     private readonly ruleCheck: NonCompliantRule,
     private readonly templatePath: string,
-    private readonly rulePath: string,
   ) { }
 
   /**
@@ -262,10 +259,7 @@ export class ViolationCheck {
     });
   }
   private generateRuleDocUrl(): string {
-    const serviceName = path.basename(path.dirname(this.rulePath));
-    const ruleName = path.basename(this.rulePath, '.guard');
-    const root = 'https://docs.aws.amazon.com/controltower/latest/userguide';
-    return `${root}/${serviceName}-rules.html#${ruleName}-description`;
+    return 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules';
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,8 +13,8 @@ export function exec(commandLine: string[], options: { cwd?: string; json?: bool
   });
 
   if (proc.error) { throw proc.error; }
-  // cfn-guard uses 5 when there are policy validation failures
-  if (proc.status !== 0 && proc.status !== 5) {
+  // cfn-guard uses 5 & 19 when there are policy validation failures
+  if (proc.status !== 0 && proc.status !== 5 && proc.status !== 19) {
     if (process.stderr) { // will be 'null' in verbose mode
       process.stderr.write(proc.stderr);
     }

--- a/test/plugin.integ.test.ts
+++ b/test/plugin.integ.test.ts
@@ -44,6 +44,33 @@ describe('CfnGuardValidator', () => {
       's3_bucket_level_public_access_prohibited_check',
     ]));
   });
+
+  test('synth fails, debuggable', () => {
+    // GIVEN
+    const app = new App({
+      context: {
+        '@aws-cdk/core:validationReportJson': true,
+      },
+    });
+
+    // WHEN
+    const stack = new Stack(app, 'Stack');
+    new s3.Bucket(stack, 'Bucket');
+
+    // THEN
+    const assembly = app.synth();
+    const validator = new CfnGuardValidator();
+    const report = validator.validate({ templatePaths: [assembly.getStackArtifact(stack.artifactId).templateFullPath] });
+    expect(validator.ruleIds).toEqual(expect.arrayContaining([
+      'apigatewaypr2',
+      's3pr1',
+    ]));
+    expect(validator.ruleIds?.length).toBeGreaterThanOrEqual(133);
+    const rules = report.violations.flatMap((v: any) => v.ruleName);
+    expect(rules).toEqual(expect.arrayContaining([
+      's3_bucket_level_public_access_prohibited_check',
+    ]));
+  });
   test('synth succeeds', () => {
     // GIVEN
     const validator = new CfnGuardValidator({

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -23,9 +23,9 @@ beforeEach(() => {
       },
     },
   });
-  execMock = jest.spyOn(utils, 'exec').mockReturnValue({
+  execMock = jest.spyOn(utils, 'exec').mockReturnValue([{
     not_compliant: [],
-  });
+  }]);
 });
 
 afterEach(() => {
@@ -61,35 +61,22 @@ describe('CfnGuardPlugin', () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     expect(validator.version).toEqual(require('../package.json').version);
     expect(validator.ruleIds).toEqual(['efsrule', 's3rule']);
-    expect(execMock).toHaveBeenCalledTimes(4);
+    expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenNthCalledWith(1, expect.arrayContaining([
-      '--rules',
-      path.join(__dirname, '../rules/control-tower/cfn-guard/efs/ct-efs-rule.guard'),
-      '--data',
-      'template-path-1',
-    ]), { json: true });
-    expect(execMock).toHaveBeenNthCalledWith(2, expect.arrayContaining([
-      '--rules',
-      path.join(__dirname, '../rules/control-tower/cfn-guard/efs/ct-efs-rule.guard'),
-      '--data',
-      'template-path-2',
-    ]), { json: true });
-    expect(execMock).toHaveBeenNthCalledWith(3, expect.arrayContaining([
       expect.stringMatching(/.*bin\/\w+\/cfn-guard$/),
       '--rules',
-      path.join(__dirname, '../rules/control-tower/cfn-guard/s3/ct-s3-rule.guard'),
+      path.join(__dirname, '../rules/control-tower/cfn-guard'),
+      '--data',
+      'template-path-1',
+      '--data',
+      'template-path-2',
       '--data',
       'template-path-1',
       '--output-format',
       'json',
       '--show-summary',
       'none',
-    ]), { json: true });
-    expect(execMock).toHaveBeenNthCalledWith(4, expect.arrayContaining([
-      '--rules',
-      path.join(__dirname, '../rules/control-tower/cfn-guard/s3/ct-s3-rule.guard'),
-      '--data',
-      'template-path-2',
+      '--structured',
     ]), { json: true });
   });
 
@@ -169,7 +156,7 @@ describe('CfnGuardPlugin', () => {
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenCalledWith(expect.arrayContaining([
       '--rules',
-      path.join(__dirname, '../rules/control-tower/cfn-guard/efs/ct-efs-rule.guard'),
+      path.join(__dirname, '../rules/control-tower/cfn-guard'),
       '--data',
       'template.json',
     ]), { json: true });
@@ -197,14 +184,10 @@ describe('CfnGuardPlugin', () => {
       templatePaths: ['template.json'],
     });
 
-    expect(execMock).toHaveBeenCalledTimes(2);
+    expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenNthCalledWith(1, expect.arrayContaining([
       '--rules',
-      path.join(__dirname, 'local-rules', 'directory', 'dir-rule.guard'),
-      '--data',
-      'template.json',
-    ]), { json: true });
-    expect(execMock).toHaveBeenNthCalledWith(2, expect.arrayContaining([
+      path.join(__dirname, 'local-rules', 'directory'),
       '--rules',
       path.join(__dirname, 'local-rules', 'file-rule.guard'),
       '--data',
@@ -219,7 +202,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -229,12 +212,12 @@ describe('CfnGuardPlugin', () => {
         fix: "[FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         ruleName: 's3_bucket_level_public_access_prohibited_check',
         violatingResources: [{
           resourceLogicalId: 'MyCustomL3ConstructBucket8C61BCA7',
-          templatePath: './tmp',
+          templatePath: 'mytemplate.json',
           locations: ['/Resources/MyCustomL3ConstructBucket8C61BCA7'],
         }],
       }],
@@ -248,7 +231,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -259,12 +242,12 @@ describe('CfnGuardPlugin', () => {
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleName: 's3_bucket_level_public_access_prohibited_check',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         violatingResources: [
           {
             resourceLogicalId: 'Bucket83908E77',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/Bucket83908E77/Properties/PublicAccessBlockConfiguration/BlockPublicAcls',
               '/Resources/Bucket83908E77/Properties/PublicAccessBlockConfiguration/BlockPublicPolicy',
@@ -274,7 +257,7 @@ describe('CfnGuardPlugin', () => {
           },
           {
             resourceLogicalId: 'Bucket25524B414',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/Bucket25524B414',
             ],
@@ -291,7 +274,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -301,12 +284,12 @@ describe('CfnGuardPlugin', () => {
         fix: "[FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         ruleName: 's3_bucket_level_public_access_prohibited_check',
         violatingResources: [{
           resourceLogicalId: 'Bucket83908E77',
-          templatePath: './tmp',
+          templatePath: 'mytemplate.json',
           locations: [
             '/Resources/Bucket83908E77/Properties/PublicAccessBlockConfiguration/BlockPublicAcls',
             '/Resources/Bucket83908E77/Properties/PublicAccessBlockConfiguration/BlockPublicPolicy',
@@ -325,7 +308,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -335,13 +318,13 @@ describe('CfnGuardPlugin', () => {
         fix: "[FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         ruleName: 's3_bucket_level_public_access_prohibited_check',
         violatingResources: [
           {
             resourceLogicalId: 'Bucket83908E77',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/Bucket83908E77/Properties/PublicAccessBlockConfiguration/BlockPublicAcls',
               '/Resources/Bucket83908E77/Properties/PublicAccessBlockConfiguration/BlockPublicPolicy',
@@ -351,7 +334,7 @@ describe('CfnGuardPlugin', () => {
           },
           {
             resourceLogicalId: 'Bucket25524B414',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/Bucket25524B414/Properties/PublicAccessBlockConfiguration/BlockPublicAcls',
               '/Resources/Bucket25524B414/Properties/PublicAccessBlockConfiguration/BlockPublicPolicy',
@@ -371,7 +354,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -381,13 +364,13 @@ describe('CfnGuardPlugin', () => {
         fix: '',
         description: 'Check was not compliant as property value [Path=/Resources/MyCustomL3ConstructBucket8C61BCA7/Properties/PublicAccessBlockConfiguration/BlockPublicAcls[L:6,C:24] Value=false] not equal to value [Path=[L:0,C:0] Value=true].',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         ruleName: 'S3_BUCKET_LEVEL_PUBLIC_ACCESS_PROHIBITED',
         violatingResources: [
           {
             resourceLogicalId: 'MyCustomL3ConstructBucket8C61BCA7',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/MyCustomL3ConstructBucket8C61BCA7/Properties/PublicAccessBlockConfiguration/BlockPublicAcls',
               '/Resources/MyCustomL3ConstructBucket8C61BCA7/Properties/PublicAccessBlockConfiguration/BlockPublicPolicy',
@@ -406,7 +389,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -416,13 +399,13 @@ describe('CfnGuardPlugin', () => {
         fix: '',
         description: 'Check was not compliant as property [Properties.ObjectLockEnabled] is missing. Value traversed to [Path=/Resources/MyCustomL3ConstructBucket8C61BCA7[L:2,C:39] Value={\"Type\":\"AWS::S3::Bucket\",\"UpdateReplacePolicy\":\"Retain\",\"DeletionPolicy\":\"Retain\",\"Metadata\":{\"aws:cdk:path\":\"CdkTestAppStack/MyCustomL3Construct/Bucket/Resource\"}}].',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         ruleName: 'S3_BUCKET_DEFAULT_LOCK_ENABLED',
         violatingResources: [
           {
             resourceLogicalId: 'MyCustomL3ConstructBucket8C61BCA7',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/MyCustomL3ConstructBucket8C61BCA7',
               '/Resources/MyCustomL3ConstructBucket8C61BCA7',
@@ -440,7 +423,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -449,14 +432,14 @@ describe('CfnGuardPlugin', () => {
       violations: [{
         description: '[CT.CLOUDTRAIL.PR.1]: Require an AWS CloudTrail trail to have encryption at rest activated',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         fix: "[FIX]: Set the 'KMSKeyId' property to a valid KMS key.",
         ruleName: 'cloud_trail_encryption_enabled_check',
         violatingResources: [
           {
             resourceLogicalId: 'CloudTrailA62D711D',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/CloudTrailA62D711D/Properties',
               '/Resources/CloudTrailA62D711D/Properties',
@@ -475,7 +458,7 @@ describe('CfnGuardPlugin', () => {
 
     // WHEN
     const result = validator.validate({
-      templatePaths: ['./tmp'],
+      templatePaths: ['mytemplate.json'],
     });
 
     // THEN
@@ -484,14 +467,14 @@ describe('CfnGuardPlugin', () => {
       violations: [{
         description: '[CT.CLOUDFRONT.PR.6]: Require an Amazon CloudFront distribution to use custom SSL/TLS certificates',
         ruleMetadata: {
-          DocumentationUrl: 'https://docs.aws.amazon.com/controltower/latest/userguide/amazon_s3-rules.html#s3-rule-description',
+          DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
         fix: "[FIX]: Provide a 'ViewerCertificate' configuration with values for 'AcmCertificateArn', 'MinimumProtocolVersion', and 'SslSupportMethod'.",
         ruleName: 'cloudfront_custom_ssl_certificate_check',
         violatingResources: [
           {
             resourceLogicalId: 'DistributionCFDistribution882A7313',
-            templatePath: './tmp',
+            templatePath: 'mytemplate.json',
             locations: [
               '/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate/CloudFrontDefaultCertificate',
               '/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate',
@@ -512,7 +495,7 @@ describe('CfnGuardPlugin', () => {
     // THEN
     expect(() => {
       validator.validate({
-        templatePaths: ['./tmp'],
+        templatePaths: ['mytemplate.json'],
       });
     }).toThrow(/CfnGuardValidator plugin failed processing/);
   });

--- a/test/test-data/guard-disjunction-resolved-check.json
+++ b/test/test-data/guard-disjunction-resolved-check.json
@@ -1,101 +1,101 @@
-{
-      "name": "",
-      "metadata": {},
-      "status": "FAIL",
-      "not_compliant": [
-        {
-          "Rule": {
-            "name": "cloudfront_custom_ssl_certificate_check",
-            "metadata": {},
-            "messages": {
-              "custom_message": null,
-              "error_message": null
-            },
-            "checks": [
-              {
-                "Rule": {
-                  "name": "check",
-                  "metadata": {},
-                  "messages": {
-                    "custom_message": "\n        [CT.CLOUDFRONT.PR.6]: Require an Amazon CloudFront distribution to use custom SSL/TLS certificates\n            [FIX]: Provide a 'ViewerCertificate' configuration with values for 'AcmCertificateArn', 'MinimumProtocolVersion', and 'SslSupportMethod'.\n        ",
-                    "error_message": null
-                  },
-                  "checks": [
-                    {
-                      "Disjunctions": {
-                        "checks": [
-                          {
-                            "Clause": {
-                              "Unary": {
-                                "context": " CloudFrontDefaultCertificate not EXISTS  ",
-                                "messages": {
-                                  "custom_message": "",
-                                  "error_message": "Check was not compliant as property [/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate/CloudFrontDefaultCertificate[L:295,C:38]] existed."
+[{
+  "name": "mytemplate.json",
+  "metadata": {},
+  "status": "FAIL",
+  "not_compliant": [
+    {
+      "Rule": {
+        "name": "cloudfront_custom_ssl_certificate_check",
+        "metadata": {},
+        "messages": {
+          "custom_message": null,
+          "error_message": null
+        },
+        "checks": [
+          {
+            "Rule": {
+              "name": "check",
+              "metadata": {},
+              "messages": {
+                "custom_message": "\n        [CT.CLOUDFRONT.PR.6]: Require an Amazon CloudFront distribution to use custom SSL/TLS certificates\n            [FIX]: Provide a 'ViewerCertificate' configuration with values for 'AcmCertificateArn', 'MinimumProtocolVersion', and 'SslSupportMethod'.\n        ",
+                "error_message": null
+              },
+              "checks": [
+                {
+                  "Disjunctions": {
+                    "checks": [
+                      {
+                        "Clause": {
+                          "Unary": {
+                            "context": " CloudFrontDefaultCertificate not EXISTS  ",
+                            "messages": {
+                              "custom_message": "",
+                              "error_message": "Check was not compliant as property [/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate/CloudFrontDefaultCertificate[L:295,C:38]] existed."
+                            },
+                            "check": {
+                              "Resolved": {
+                                "value": {
+                                  "path": "/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate/CloudFrontDefaultCertificate",
+                                  "value": true
                                 },
-                                "check": {
-                                  "Resolved": {
-                                    "value": {
-                                      "path": "/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate/CloudFrontDefaultCertificate",
-                                      "value": true
-                                    },
-                                    "comparison": [
-                                      "Exists",
-                                      true
-                                    ]
-                                  }
-                                }
+                                "comparison": [
+                                  "Exists",
+                                  true
+                                ]
                               }
                             }
                           }
-                        ]
+                        }
                       }
-                    },
-                    {
-                      "Disjunctions": {
-                        "checks": [
-                          {
-                            "Rule": {
-                              "name": "check_custom_acm_certificate_provided",
-                              "metadata": {},
-                              "messages": {
-                                "custom_message": null,
-                                "error_message": null
-                              },
-                              "checks": [
-                                {
-                                  "Block": {
-                                    "context": "GuardBlockAccessClause#Location[file:ct-cloudfront-pr-6.guard, line:114, column:5]",
-                                    "messages": {
-                                      "custom_message": "",
-                                      "error_message": "Check was not compliant as property [AcmCertificateArn] is missing. Value traversed to [Path=/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate[L:294,C:26] Value={\"CloudFrontDefaultCertificate\":true}]"
-                                    },
-                                    "unresolved": {
-                                      "traversed_to": {
-                                        "path": "/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate",
-                                        "value": {
-                                          "CloudFrontDefaultCertificate": true
-                                        }
-                                      },
-                                      "remaining_query": "AcmCertificateArn",
-                                      "reason": "Could not find key AcmCertificateArn inside struct at path /Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate[L:294,C:26]"
+                    ]
+                  }
+                },
+                {
+                  "Disjunctions": {
+                    "checks": [
+                      {
+                        "Rule": {
+                          "name": "check_custom_acm_certificate_provided",
+                          "metadata": {},
+                          "messages": {
+                            "custom_message": null,
+                            "error_message": null
+                          },
+                          "checks": [
+                            {
+                              "Block": {
+                                "context": "GuardBlockAccessClause#Location[file:ct-cloudfront-pr-6.guard, line:114, column:5]",
+                                "messages": {
+                                  "custom_message": "",
+                                  "error_message": "Check was not compliant as property [AcmCertificateArn] is missing. Value traversed to [Path=/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate[L:294,C:26] Value={\"CloudFrontDefaultCertificate\":true}]"
+                                },
+                                "unresolved": {
+                                  "traversed_to": {
+                                    "path": "/Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate",
+                                    "value": {
+                                      "CloudFrontDefaultCertificate": true
                                     }
-                                  }
+                                  },
+                                  "remaining_query": "AcmCertificateArn",
+                                  "reason": "Could not find key AcmCertificateArn inside struct at path /Resources/DistributionCFDistribution882A7313/Properties/DistributionConfig/ViewerCertificate[L:294,C:26]"
                                 }
-                              ]
+                              }
                             }
-                          }
-                        ]
+                          ]
+                        }
                       }
-                    }
-                  ]
+                    ]
+                  }
                 }
-              }
-            ]
+              ]
+            }
           }
-        }
-      ],
-      "not_applicable": [
-        "cloudfront_custom_ssl_certificate_check"
-      ],
-      "compliant": []
+        ]
+      }
     }
+  ],
+  "not_applicable": [
+    "cloudfront_custom_ssl_certificate_check"
+  ],
+  "compliant": []
+}]

--- a/test/test-data/guard-mix-checks-and-nested-checks.json
+++ b/test/test-data/guard-mix-checks-and-nested-checks.json
@@ -1,5 +1,5 @@
-{
-    "name": "",
+[{
+    "name": "mytemplate.json",
     "metadata": {},
     "status": "FAIL",
     "not_compliant": [
@@ -150,4 +150,4 @@
         "cloud_trail_encryption_enabled_check"
     ],
     "compliant": []
-}
+}]

--- a/test/test-data/guard-resolved-clause-check.json
+++ b/test/test-data/guard-resolved-clause-check.json
@@ -1,5 +1,5 @@
-{
-  "name": "",
+[{
+  "name": "mytemplate.json",
   "metadata": {},
   "status": "FAIL",
   "not_compliant": [
@@ -99,4 +99,4 @@
   ],
   "not_applicable": [],
   "compliant": []
-}
+}]

--- a/test/test-data/guard-resolved-rule-check-multiple-resources.json
+++ b/test/test-data/guard-resolved-rule-check-multiple-resources.json
@@ -1,5 +1,5 @@
-{
-  "name": "",
+[{
+  "name": "mytemplate.json",
   "metadata": {},
   "status": "FAIL",
   "not_compliant": [
@@ -248,4 +248,4 @@
     "s3_bucket_level_public_access_prohibited_check"
   ],
   "compliant": []
-}
+}]

--- a/test/test-data/guard-resolved-rule-check.json
+++ b/test/test-data/guard-resolved-rule-check.json
@@ -1,5 +1,5 @@
-{
-  "name": "",
+[{
+  "name": "mytemplate.json",
   "metadata": {},
   "status": "FAIL",
   "not_compliant": [
@@ -140,4 +140,4 @@
     "s3_bucket_level_public_access_prohibited_check"
   ],
   "compliant": []
-}
+}]

--- a/test/test-data/guard-unresolved-clause-check.json
+++ b/test/test-data/guard-unresolved-clause-check.json
@@ -1,5 +1,5 @@
-{
-  "name": "",
+[{
+  "name": "mytemplate.json",
   "metadata": {},
   "status": "FAIL",
   "not_compliant": [
@@ -86,4 +86,4 @@
   ],
   "not_applicable": [],
   "compliant": []
-}
+}]

--- a/test/test-data/guard-unresolved-nested-rule-check.json
+++ b/test/test-data/guard-unresolved-nested-rule-check.json
@@ -1,5 +1,5 @@
-{
-  "name": "",
+[{
+  "name": "mytemplate.json",
   "metadata": {},
   "status": "FAIL",
   "not_compliant": [
@@ -176,4 +176,4 @@
     "s3_bucket_level_public_access_prohibited_check"
   ],
   "compliant": []
-}
+}]

--- a/test/test-data/guard-unresolved-rule-check.json
+++ b/test/test-data/guard-unresolved-rule-check.json
@@ -1,5 +1,5 @@
-{
-  "name": "",
+[{
+  "name": "mytemplate.json",
   "metadata": {},
   "status": "FAIL",
   "not_compliant": [
@@ -56,4 +56,4 @@
     "s3_bucket_level_public_access_prohibited_check"
   ],
   "compliant": []
-}
+}]


### PR DESCRIPTION
This PR upgrades `cfn-guard` to the latest major version [3.0.0](https://github.com/aws-cloudformation/cloudformation-guard/releases/tag/3.0.0)

The major feature that we are taking advantage of is the new `--structured` flag which combines all the output into a json parseable list. I tested this out in a medium sized project and it reduced the time to execute the plugin from ~2 minutes ~2 seconds!

Fixes #