### PR TITLE
fix: disabledRules not respected

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -144,7 +144,7 @@ export class CfnGuardValidator implements IPolicyValidationPluginBeta1 {
   private execGuard(config: GuardExecutionConfig): Pick<PolicyValidationPluginReportBeta1, 'success' | 'violations'> {
     const flags = [
       'validate',
-      ...config.rulePaths.flatMap(rule => ['--rules', rule]),
+      ...this.getRules(config.rulePaths).flatMap(rule => ['--rules', rule]),
       ...config.templatePaths.flatMap(template => ['--data', template]),
       '--output-format', 'json',
       '--show-summary', 'none',

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -156,9 +156,13 @@ describe('CfnGuardPlugin', () => {
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenCalledWith(expect.arrayContaining([
       '--rules',
-      path.join(__dirname, '../rules/control-tower/cfn-guard'),
+      path.join(__dirname, '../rules/control-tower/cfn-guard/efs'),
       '--data',
       'template.json',
+    ]), { json: true });
+    expect(execMock).toHaveBeenCalledWith(expect.arrayContaining([
+      '--rules',
+      expect.not.stringContaining('s3'),
     ]), { json: true });
   });
 


### PR DESCRIPTION
In the guard 3.0 refactor the logic for disabling rules was dropped. This adds it back in.

closes #123