### PR TITLE
feat: add support for arm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -198,3 +198,31 @@ jobs:
         run: cd .repo && npx projen package:dotnet
       - name: Collect dotnet Artifact
         run: mv .repo/dist dist
+  package-go:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions: {}
+    if: "! needs.build.outputs.self_mutation_happened"
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,3 +218,39 @@ jobs:
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: npx -p publib@latest publib-nuget
+  release_golang:
+    name: Publish to GitHub Go Module Repository
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    if: needs.release.outputs.latest_commit == github.sha
+    steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ^1.16.0
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: build-artifact
+          path: dist
+      - name: Restore build artifact permissions
+        run: cd dist && setfacl --restore=permissions-backup.acl
+        continue-on-error: true
+      - name: Prepare Repository
+        run: mv dist .repo
+      - name: Install Dependencies
+        run: cd .repo && yarn install --check-files --frozen-lockfile
+      - name: Create go artifact
+        run: cd .repo && npx projen package:go
+      - name: Collect go Artifact
+        run: mv .repo/dist dist
+      - name: Release
+        env:
+          GIT_USER_NAME: github-actions
+          GIT_USER_EMAIL: github-actions@github.com
+          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}
+        run: npx -p publib@latest publib-golang

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -193,6 +193,9 @@
         },
         {
           "spawn": "package:dotnet"
+        },
+        {
+          "spawn": "package:go"
         }
       ]
     },
@@ -202,6 +205,15 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target dotnet"
+        }
+      ]
+    },
+    "package:go": {
+      "name": "package:go",
+      "description": "Create go language bindings",
+      "steps": [
+        {
+          "exec": "jsii-pacmak -v --target go"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -57,6 +57,9 @@ const project = new CdklabsJsiiProject({
     dotNetNamespace: 'Cdklabs.CdkValidatorCfnGuard',
     packageId: 'Cdklabs.CdkValidatorCfnGuard',
   },
+  publishToGo: {
+    moduleName: 'github.com/cdklabs/cdk-validator-cfnguard-go',
+  },
 
   jestOptions: {
     jestConfig: {

--- a/guard-version.json
+++ b/guard-version.json
@@ -1,4 +1,4 @@
 {
-  "release_id": 110407150,
-  "version": "3.0.0"
+  "release_id": 129981405,
+  "version": "3.0.2"
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:dotnet": "npx projen package:dotnet",
+    "package:go": "npx projen package:go",
     "package:java": "npx projen package:java",
     "package:js": "npx projen package:js",
     "package:python": "npx projen package:python",
@@ -151,6 +152,9 @@
       "dotnet": {
         "namespace": "Cdklabs.CdkValidatorCfnGuard",
         "packageId": "Cdklabs.CdkValidatorCfnGuard"
+      },
+      "go": {
+        "moduleName": "github.com/cdklabs/cdk-validator-cfnguard-go"
       }
     },
     "tsc": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -77,6 +77,7 @@ export class CfnGuardValidator implements IPolicyValidationPluginBeta1 {
     }
     this.rulesPaths.push(...props.rules ?? []);
     const osPlatform = os.platform();
+    const osArch = os.arch();
     // guard calls it ubuntu but seems to apply to all linux
     // https://github.com/aws-cloudformation/cloudformation-guard/blob/184002cdfc0ae9e29c61995aae41b7d1f1d3b26c/install-guard.sh#L43-L46
     const platform = osPlatform === 'linux'
@@ -86,7 +87,12 @@ export class CfnGuardValidator implements IPolicyValidationPluginBeta1 {
     if (!platform) {
       throw new Error(`${os.platform()} not supported, must be either 'darwin' or 'linux'`);
     }
-    this.guard = path.join(__dirname, '..', 'bin', platform, 'cfn-guard');
+
+    if (!['arm64', 'x64'].includes(osArch)) {
+      throw new Error(`${osArch} not supported, must be either 'arm64' or x86_64`);
+    }
+
+    this.guard = path.join(__dirname, '..', 'bin', platform, osArch, 'cfn-guard');
     this.ruleIds = this.rulesPaths.flatMap(rule => {
       const parsed = path.parse(rule);
       if (rule === defaultRulesPath || parsed.dir.startsWith(defaultRulesPath)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,7 @@ import { spawnSync } from 'child_process';
 export function exec(commandLine: string[], options: { cwd?: string; json?: boolean; verbose?: boolean; env?: any } = { }): any {
   const proc = spawnSync(commandLine[0], commandLine.slice(1), {
     stdio: ['ignore', 'pipe', options.verbose ? 'inherit' : 'pipe'], // inherit STDERR in verbose mode
+    maxBuffer: 10485760, // 10 MB. Default is 1MB
     env: {
       ...process.env,
       ...options.env,

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -63,7 +63,7 @@ describe('CfnGuardPlugin', () => {
     expect(validator.ruleIds).toEqual(['efsrule', 's3rule']);
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenNthCalledWith(1, expect.arrayContaining([
-      expect.stringMatching(/.*bin\/\w+\/cfn-guard$/),
+      expect.stringMatching(/.*bin\/\w+\/\w+\/cfn-guard$/),
       '--rules',
       path.join(__dirname, '../rules/control-tower/cfn-guard'),
       '--data',


### PR DESCRIPTION
cfnguard added ARM binaries in v3.0.1. This PR updates the `bundle-guard` script to handle bundle both `arm64` & `x86_64`.

Also doing a couple of other minor things that I came across in testing.

1. Adding Go publishing (Will need to create a `cdklabs/cdk-validator-cfnguard-go` repo)
2. Increasing the `maxBuffer` size from 1-10MB. Long term fix is probably to switch from `spawnSync` to `spawn`.

closes #229, re #154, closes #101

Fixes #