### PR TITLE
feat: update guard version up to 3.1.1

### DIFF
--- a/guard-version.json
+++ b/guard-version.json
@@ -1,4 +1,4 @@
 {
-  "release_id": 110407150,
-  "version": "3.0.0"
+  "release_id": 150967690,
+  "version": "3.1.1"
 }


### PR DESCRIPTION
This change increases the version of [aws-cloudformation/cloudformation-guard ](https://github.com/aws-cloudformation/cloudformation-guard) to the latest one i.e. `3.1.1`. 

I'm proposing this change to add support for ARM architectures, which currently are failing with the  `3.0.0` version. 

This is the fix that resolves the https://github.com/aws-cloudformation/cloudformation-guard/issues/314 issue, which was merged after the `3.0.0` version:
https://github.com/aws-cloudformation/cloudformation-guard/pull/387