### PR TITLE
feat: add architecture qualifier to cfn-guard

### DIFF
--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -63,7 +63,7 @@ describe('CfnGuardPlugin', () => {
     expect(validator.ruleIds).toEqual(['efsrule', 's3rule']);
     expect(execMock).toHaveBeenCalledTimes(1);
     expect(execMock).toHaveBeenNthCalledWith(1, expect.arrayContaining([
-      expect.stringMatching(/.*bin\/\w+\/cfn-guard$/),
+      expect.stringMatching(/.*bin\/\w+\/\w+\/cfn-guard$/),
       '--rules',
       path.join(__dirname, '../rules/control-tower/cfn-guard'),
       '--data',


### PR DESCRIPTION
After having performed a version bump of the `cfn-guard` dependency up to the `3.1.1` version, which now supports the ARM architecture, I've found that the way in which the bundle is generated was not considering the multi-architecture case, ending on not being able to use `cdk-validator-cfnguard` on ARM architectures. 

To resolve it, I'm improving the way in which the `cfn-guard` is bundled, such that from now it will be qualified with the architecture.



This Pull Request is related to https://github.com/cdklabs/cdk-validator-cfnguard/pull/519