### PR TITLE
fix: strip '[FIX]:' prefix from violation fix text

### DIFF
--- a/src/check.ts
+++ b/src/check.ts
@@ -232,7 +232,8 @@ export class ViolationCheck {
         message.forEach(m => {
           const mes = m.trim();
           if (mes.startsWith('[FIX]')) {
-            this.violation.fix = mes;
+            // Detect on the '[FIX]' marker but do not store it.
+            this.violation.fix = mes.replace(/^\[FIX\]:\s*/, '');
           } else {
             this.violation.description = mes;
           }

--- a/test/plugin.test.ts
+++ b/test/plugin.test.ts
@@ -213,7 +213,7 @@ describe('CfnGuardPlugin', () => {
     expect(result).toEqual({
       success: false,
       violations: [{
-        fix: "[FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
+        fix: "The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleMetadata: {
           DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
@@ -242,7 +242,7 @@ describe('CfnGuardPlugin', () => {
     expect(result).toEqual({
       success: false,
       violations: [{
-        fix: "[FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
+        fix: "The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleName: 's3_bucket_level_public_access_prohibited_check',
         ruleMetadata: {
@@ -285,7 +285,7 @@ describe('CfnGuardPlugin', () => {
     expect(result).toEqual({
       success: false,
       violations: [{
-        fix: "[FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
+        fix: "The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleMetadata: {
           DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
@@ -319,7 +319,7 @@ describe('CfnGuardPlugin', () => {
     expect(result).toEqual({
       success: false,
       violations: [{
-        fix: "[FIX]: The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
+        fix: "The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.",
         description: '[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured',
         ruleMetadata: {
           DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
@@ -438,7 +438,7 @@ describe('CfnGuardPlugin', () => {
         ruleMetadata: {
           DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
-        fix: "[FIX]: Set the 'KMSKeyId' property to a valid KMS key.",
+        fix: "Set the 'KMSKeyId' property to a valid KMS key.",
         ruleName: 'cloud_trail_encryption_enabled_check',
         violatingResources: [
           {
@@ -473,7 +473,7 @@ describe('CfnGuardPlugin', () => {
         ruleMetadata: {
           DocumentationUrl: 'https://github.com/cdklabs/cdk-validator-cfnguard#bundled-control-tower-rules',
         },
-        fix: "[FIX]: Provide a 'ViewerCertificate' configuration with values for 'AcmCertificateArn', 'MinimumProtocolVersion', and 'SslSupportMethod'.",
+        fix: "Provide a 'ViewerCertificate' configuration with values for 'AcmCertificateArn', 'MinimumProtocolVersion', and 'SslSupportMethod'.",
         ruleName: 'cloudfront_custom_ssl_certificate_check',
         violatingResources: [
           {
@@ -487,6 +487,25 @@ describe('CfnGuardPlugin', () => {
         ],
       }],
     });
+  });
+
+  test('strips the [FIX] prefix from the fix but leaves the description rule-id prefix intact', () => {
+    // GIVEN
+    execMock.mockReturnValue(getData('guard-unresolved-rule-check.json'));
+    const validator = new plugin.CfnGuardValidator();
+
+    // WHEN
+    const result = validator.validate({
+      templatePaths: ['mytemplate.json'],
+    });
+
+    // THEN
+    const violation = result.violations[0];
+    // the '[FIX]:' authoring marker is removed so consumers do not render it doubled
+    expect(violation.fix).not.toMatch(/^\[FIX\]/);
+    expect(violation.fix).toEqual("The parameters 'BlockPublicAcls', 'BlockPublicPolicy', 'IgnorePublicAcls', 'RestrictPublicBuckets' must be set to true under the bucket-level 'PublicAccessBlockConfiguration'.");
+    // only '[FIX]' is stripped; the description keeps its rule-id prefix
+    expect(violation.description).toEqual('[CT.S3.PR.1]: Require an Amazon S3 bucket to have block public access settings configured');
   });
 
   test('guard fails', () => {


### PR DESCRIPTION
cfn-guard Control Tower rule messages carry a '[FIX]:' authoring marker in custom_message. The plugin detects the fix line with startsWith('[FIX]') but also stored the marker verbatim in the violation fix field, so consumers that add their own label rendered it doubled (e.g. the CDK CLI: 'How to fix: [FIX]: ...').

Strip the leading '[FIX]:' before storing. The description field is unchanged and keeps its rule-id prefix; rule identity remains available via ruleName and ruleMetadata.
